### PR TITLE
feat: cast everything to const for gcc < 5.X

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -543,8 +543,8 @@ endif
 ifeq ($(TARGET_DC),1)
   #Notes from neo
   #-gdwarf-2 -gstrict-dwarf -g3 --ffunction-sections -fdata-sections -Wl,-gc-sections
-  PLATFORM_CFLAGS  := -DTARGET_DC -D_arch_dreamcast -DNDEBUG -ffunction-sections -fdata-sections -Isrc/pc/gfx/gldc -Wall -Wextra
-  PLATFORM_LDFLAGS := -Wl,-gc-sections
+  PLATFORM_CFLAGS  := -DTARGET_DC -D_arch_dreamcast -DNDEBUG -ffunction-sections -fdata-sections -Isrc/pc/gfx/gldc -Wall -Wextra -std=c99
+  PLATFORM_LDFLAGS := -Wl,--gc-sections
 endif
 ifeq ($(TARGET_WEB),1)
   PLATFORM_CFLAGS  := -DTARGET_WEB

--- a/include/macros.h
+++ b/include/macros.h
@@ -69,4 +69,8 @@
 #define VIRTUAL_TO_PHYSICAL2(addr)  ((void *)(addr))
 #endif
 
+#ifndef M_PI
+#define M_PI (3.14159265358979323846)
+#endif
+
 #endif // MACROS_H

--- a/src/audio/synthesis.c
+++ b/src/audio/synthesis.c
@@ -660,7 +660,7 @@ u64 *synthesis_process_notes(s16 *aiBuf, s32 bufLen, u64 *cmd) {
     s32 s5Aligned;
 #endif
     s32 resampledTempLen;                    // spD8, spAC
-    u16 noteSamplesDmemAddrBeforeResampling; // spD6, spAA
+    u16 noteSamplesDmemAddrBeforeResampling = 0; // spD6, spAA
 
 
 #ifndef VERSION_EU

--- a/src/engine/math_util.c
+++ b/src/engine/math_util.c
@@ -21,101 +21,85 @@ static inline int equals(const float a, const float b)
         return (a + ROUNDING_ERROR_f32 >= b) && (a - ROUNDING_ERROR_f32 <= b);
 }
 
-// These functions have bogus return values.
-// Disable the compiler warning.
-#pragma GCC diagnostic push
-#pragma GCC diagnostic ignored "-Wreturn-local-addr"
-
 /// Copy vector 'src' to 'dest'
-void *vec3f_copy(Vec3f dest, Vec3f src) {
+void vec3f_copy(Vec3f dest, Vec3f src) {
     dest[0] = src[0];
     dest[1] = src[1];
     dest[2] = src[2];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Set vector 'dest' to (x, y, z)
-void *vec3f_set(Vec3f dest, f32 x, f32 y, f32 z) {
+void vec3f_set(Vec3f dest, f32 x, f32 y, f32 z) {
     dest[0] = x;
     dest[1] = y;
     dest[2] = z;
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Add vector 'a' to 'dest'
-void *vec3f_add(Vec3f dest, Vec3f a) {
+void vec3f_add(Vec3f dest, Vec3f a) {
     dest[0] += a[0];
     dest[1] += a[1];
     dest[2] += a[2];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Make 'dest' the sum of vectors a and b.
-void *vec3f_sum(Vec3f dest, Vec3f a, Vec3f b) {
+void vec3f_sum(Vec3f dest, Vec3f a, Vec3f b) {
     dest[0] = a[0] + b[0];
     dest[1] = a[1] + b[1];
     dest[2] = a[2] + b[2];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Copy vector src to dest
-void *vec3s_copy(Vec3s dest, Vec3s src) {
+void vec3s_copy(Vec3s dest, Vec3s src) {
     dest[0] = src[0];
     dest[1] = src[1];
     dest[2] = src[2];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Set vector 'dest' to (x, y, z)
-void *vec3s_set(Vec3s dest, s16 x, s16 y, s16 z) {
+void vec3s_set(Vec3s dest, s16 x, s16 y, s16 z) {
     dest[0] = x;
     dest[1] = y;
     dest[2] = z;
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Add vector a to 'dest'
-void *vec3s_add(Vec3s dest, Vec3s a) {
+void vec3s_add(Vec3s dest, Vec3s a) {
     dest[0] += a[0];
     dest[1] += a[1];
     dest[2] += a[2];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Make 'dest' the sum of vectors a and b.
-void *vec3s_sum(Vec3s dest, Vec3s a, Vec3s b) {
+void vec3s_sum(Vec3s dest, Vec3s a, Vec3s b) {
     dest[0] = a[0] + b[0];
     dest[1] = a[1] + b[1];
     dest[2] = a[2] + b[2];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Subtract vector a from 'dest'
-void *vec3s_sub(Vec3s dest, Vec3s a) {
+void vec3s_sub(Vec3s dest, Vec3s a) {
     dest[0] -= a[0];
     dest[1] -= a[1];
     dest[2] -= a[2];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Convert short vector a to float vector 'dest'
-void *vec3s_to_vec3f(Vec3f dest, Vec3s a) {
+void vec3s_to_vec3f(Vec3f dest, Vec3s a) {
     dest[0] = a[0];
     dest[1] = a[1];
     dest[2] = a[2];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /**
  * Convert float vector a to a short vector 'dest' by rounding the components
  * to the nearest integer.
  */
-void *vec3f_to_vec3s(Vec3s dest, Vec3f a) {
+void vec3f_to_vec3s(Vec3s dest, Vec3f a) {
     // add/subtract 0.5 in order to round to the nearest s32 instead of truncating
     dest[0] = a[0] + ((a[0] > 0) ? 0.5f : -0.5f);
     dest[1] = a[1] + ((a[1] > 0) ? 0.5f : -0.5f);
     dest[2] = a[2] + ((a[2] > 0) ? 0.5f : -0.5f);
-    return &dest; //! warning: function returns address of local variable
 }
 
 /**
@@ -123,33 +107,28 @@ void *vec3f_to_vec3s(Vec3s dest, Vec3f a) {
  * It is similar to vec3f_cross, but it calculates the vectors (c-b) and (b-a)
  * at the same time.
  */
-void *find_vector_perpendicular_to_plane(Vec3f dest, Vec3f a, Vec3f b, Vec3f c) {
+void find_vector_perpendicular_to_plane(Vec3f dest, Vec3f a, Vec3f b, Vec3f c) {
     dest[0] = (b[1] - a[1]) * (c[2] - b[2]) - (c[1] - b[1]) * (b[2] - a[2]);
     dest[1] = (b[2] - a[2]) * (c[0] - b[0]) - (c[2] - b[2]) * (b[0] - a[0]);
     dest[2] = (b[0] - a[0]) * (c[1] - b[1]) - (c[0] - b[0]) * (b[1] - a[1]);
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Make vector 'dest' the cross product of vectors a and b.
-void *vec3f_cross(Vec3f dest, Vec3f a, Vec3f b) {
+void vec3f_cross(Vec3f dest, Vec3f a, Vec3f b) {
     dest[0] = a[1] * b[2] - b[1] * a[2];
     dest[1] = a[2] * b[0] - b[2] * a[0];
     dest[2] = a[0] * b[1] - b[0] * a[1];
-    return &dest; //! warning: function returns address of local variable
 }
 
 /// Scale vector 'dest' so it has length 1
-void *vec3f_normalize(Vec3f dest) {
+void vec3f_normalize(Vec3f dest) {
     //! Possible division by zero
     f32 invsqrt = 1.0f / sqrtf(dest[0] * dest[0] + dest[1] * dest[1] + dest[2] * dest[2]);
 
     dest[0] *= invsqrt;
     dest[1] *= invsqrt;
     dest[2] *= invsqrt;
-    return &dest; //! warning: function returns address of local variable
 }
-
-#pragma GCC diagnostic pop
 
 /// Copy matrix 'src' to 'dest'
 void mtxf_copy(Mat4 dest, Mat4 src) {

--- a/src/engine/math_util.h
+++ b/src/engine/math_util.h
@@ -32,20 +32,20 @@ extern f32 gCosineTable[];
 
 #define sqr(x) ((x) * (x))
 
-void *vec3f_copy(Vec3f dest, Vec3f src);
-void *vec3f_set(Vec3f dest, f32 x, f32 y, f32 z);
-void *vec3f_add(Vec3f dest, Vec3f a);
-void *vec3f_sum(Vec3f dest, Vec3f a, Vec3f b);
-void *vec3s_copy(Vec3s dest, Vec3s src);
-void *vec3s_set(Vec3s dest, s16 x, s16 y, s16 z);
-void *vec3s_add(Vec3s dest, Vec3s a);
-void *vec3s_sum(Vec3s dest, Vec3s a, Vec3s b);
-void *vec3s_sub(Vec3s dest, Vec3s a);
-void *vec3s_to_vec3f(Vec3f dest, Vec3s a);
-void *vec3f_to_vec3s(Vec3s dest, Vec3f a);
-void *find_vector_perpendicular_to_plane(Vec3f dest, Vec3f a, Vec3f b, Vec3f c);
-void *vec3f_cross(Vec3f dest, Vec3f a, Vec3f b);
-void *vec3f_normalize(Vec3f dest);
+void vec3f_copy(Vec3f dest, Vec3f src);
+void vec3f_set(Vec3f dest, f32 x, f32 y, f32 z);
+void vec3f_add(Vec3f dest, Vec3f a);
+void vec3f_sum(Vec3f dest, Vec3f a, Vec3f b);
+void vec3s_copy(Vec3s dest, Vec3s src);
+void vec3s_set(Vec3s dest, s16 x, s16 y, s16 z);
+void vec3s_add(Vec3s dest, Vec3s a);
+void vec3s_sum(Vec3s dest, Vec3s a, Vec3s b);
+void vec3s_sub(Vec3s dest, Vec3s a);
+void vec3s_to_vec3f(Vec3f dest, Vec3s a);
+void vec3f_to_vec3s(Vec3s dest, Vec3f a);
+void find_vector_perpendicular_to_plane(Vec3f dest, Vec3f a, Vec3f b, Vec3f c);
+void vec3f_cross(Vec3f dest, Vec3f a, Vec3f b);
+void vec3f_normalize(Vec3f dest);
 void mtxf_copy(Mat4 dest, Mat4 src);
 void mtxf_identity(Mat4 mtx);
 void mtxf_translate(Mat4 dest, Vec3f b);

--- a/src/game/mario_actions_cutscene.c
+++ b/src/game/mario_actions_cutscene.c
@@ -1487,7 +1487,7 @@ s32 act_squished(struct MarioState *m) {
     UNUSED s32 pad;
     f32 squishAmount;
     f32 spaceUnderCeil;
-    s16 surfAngle;
+    s16 surfAngle = 0;
     s32 underSteepSurf = FALSE; // seems to be responsible for setting velocity?
 
     if ((spaceUnderCeil = m->ceilHeight - m->floorHeight) < 0) {

--- a/src/goddard/draw_objects.c
+++ b/src/goddard/draw_objects.c
@@ -251,7 +251,7 @@ void draw_shape_2d(struct ObjShape *shape, s32 flag, UNUSED f32 c, UNUSED f32 d,
         sp1C.y = g;
         sp1C.z = h;
         if (gViewUpdateCamera != NULL) {
-            gd_rotate_and_translate_vec3f(&sp1C, &gViewUpdateCamera->unkE8);
+            gd_rotate_and_translate_vec3f(&sp1C, (const Mat4f *)&gViewUpdateCamera->unkE8);
         }
         translate_load_mtx_gddl(sp1C.x, sp1C.y, sp1C.z);
     }
@@ -686,7 +686,7 @@ void func_80179B64(struct ObjGroup *group) {
 
 /* 22836C -> 228498 */
 void func_80179B9C(struct GdVec3f *pos, struct ObjCamera *cam, struct ObjView *view) {
-    gd_rotate_and_translate_vec3f(pos, &cam->unkE8);
+    gd_rotate_and_translate_vec3f(pos, (const Mat4f *)&cam->unkE8);
     if (pos->z > -256.0f) {
         return;
     }

--- a/src/goddard/dynlist_proc.c
+++ b/src/goddard/dynlist_proc.c
@@ -2918,14 +2918,14 @@ void d_get_matrix(Mat4f *dst) {
     dynobj = sDynListCurObj;
     switch (sDynListCurObj->type) {
         case OBJ_TYPE_NETS:
-            gd_copy_mat4f(&((struct ObjNet *) dynobj)->mat128, dst);
+            gd_copy_mat4f((const Mat4f *)&((struct ObjNet *) dynobj)->mat128, dst);
             break;
             break; // lol
         case OBJ_TYPE_JOINTS:
-            gd_copy_mat4f(&((struct ObjJoint *) dynobj)->matE8, dst);
+            gd_copy_mat4f((const Mat4f *)&((struct ObjJoint *) dynobj)->matE8, dst);
             break;
         case OBJ_TYPE_CAMERAS:
-            gd_copy_mat4f(&((struct ObjCamera *) dynobj)->unkE8, dst);
+            gd_copy_mat4f((const Mat4f *)&((struct ObjCamera *) dynobj)->unkE8, dst);
             break;
         case OBJ_TYPE_PARTICLES:
             gd_set_identity_mat4(dst);
@@ -2949,16 +2949,16 @@ void d_set_matrix(Mat4f *src) {
 
     switch (sDynListCurObj->type) {
         case OBJ_TYPE_NETS:
-            gd_copy_mat4f(src, &((struct ObjNet *) sDynListCurObj)->mat128);
+            gd_copy_mat4f((const Mat4f *)src, &((struct ObjNet *) sDynListCurObj)->mat128);
             //! @bug When setting an `ObjNet` matrix, the source is copied twice
             //!      due to a probable copy-paste line repeat error
-            gd_copy_mat4f(src, &((struct ObjNet *) sDynListCurObj)->mat128);
+            gd_copy_mat4f((const Mat4f *)src, &((struct ObjNet *) sDynListCurObj)->mat128);
             break;
         case OBJ_TYPE_JOINTS:
-            gd_copy_mat4f(src, &((struct ObjJoint *) sDynListCurObj)->matE8);
+            gd_copy_mat4f((const Mat4f *)src, &((struct ObjJoint *) sDynListCurObj)->matE8);
             break;
         case OBJ_TYPE_CAMERAS:
-            gd_copy_mat4f(src, &((struct ObjCamera *) sDynListCurObj)->unk64);
+            gd_copy_mat4f((const Mat4f *)src, &((struct ObjCamera *) sDynListCurObj)->unk64);
             break;
         default:
             fatal_printf("%s: Object '%s'(%x) does not support this function.", "dSetMatrix()",
@@ -2977,10 +2977,10 @@ void d_set_rot_mtx(Mat4f *src) {
 
     switch (sDynListCurObj->type) {
         case OBJ_TYPE_JOINTS:
-            gd_copy_mat4f(src, &((struct ObjJoint *) sDynListCurObj)->mat128);
+            gd_copy_mat4f((const Mat4f *)src, &((struct ObjJoint *) sDynListCurObj)->mat128);
             break;
         case OBJ_TYPE_NETS:
-            gd_copy_mat4f(src, &((struct ObjNet *) sDynListCurObj)->mat168);
+            gd_copy_mat4f((const Mat4f *)src, &((struct ObjNet *) sDynListCurObj)->mat168);
             break;
         default:
             fatal_printf("%s: Object '%s'(%x) does not support this function.", "dSetRMatrix()",
@@ -3021,10 +3021,10 @@ void d_set_idn_mtx(Mat4f *src) {
     dynobj = sDynListCurObj;
     switch (sDynListCurObj->type) {
         case OBJ_TYPE_NETS:
-            gd_copy_mat4f(src, &((struct ObjNet *) dynobj)->matE8);
+            gd_copy_mat4f((const Mat4f *)src, &((struct ObjNet *) dynobj)->matE8);
             break;
         case OBJ_TYPE_JOINTS:
-            gd_copy_mat4f(src, &((struct ObjJoint *) dynobj)->mat168);
+            gd_copy_mat4f((const Mat4f *)src, &((struct ObjJoint *) dynobj)->mat168);
             break;
         case OBJ_TYPE_LIGHTS:
             ((struct ObjLight *) dynobj)->position.x = (*src)[3][0];

--- a/src/goddard/gd_math.c
+++ b/src/goddard/gd_math.c
@@ -284,7 +284,7 @@ void UNUSED gd_rot_mat_about_row(Mat4f *mat, s32 row, f32 ang) {
     vec.z = (*mat)[row][2];
 
     gd_create_rot_mat_angular(&rot, &vec, ang / 2.0);
-    gd_mult_mat4f(mat, &rot, mat);
+    gd_mult_mat4f((const Mat4f *)mat, (const Mat4f *)&rot, mat);
 }
 
 /**
@@ -316,7 +316,7 @@ void gd_absrot_mat4(Mat4f *mtx, s32 axisnum, f32 ang) {
     }
 
     gd_create_rot_mat_angular(&rMat, &rot, ang / 2.0); //? 2.0f
-    gd_mult_mat4f(mtx, &rMat, mtx);
+    gd_mult_mat4f((const Mat4f *)mtx, (const Mat4f *)&rMat, mtx);
 }
 
 
@@ -864,7 +864,7 @@ void gd_mult_mat4f(const Mat4f *mA, const Mat4f *mB, Mat4f *dst) {
     Mat4f res;
 
     MAT4_MULTIPLY((*mA), (*mB), res);
-    gd_copy_mat4f(&res, dst);
+    gd_copy_mat4f((const Mat4f *)&res, dst);
 }
 
 #undef MAT4_MULTIPLY
@@ -959,8 +959,8 @@ void UNUSED gd_rot_mat_offset(Mat4f *dst, f32 x, f32 y, f32 z, s32 copy) {
 
     gd_create_rot_matrix(&rot, &vec, s, c);
     if (!copy) {
-        gd_mult_mat4f(dst, &rot, dst);
+        gd_mult_mat4f((const Mat4f *)dst, (const Mat4f *)&rot, dst);
     } else {
-        gd_copy_mat4f(&rot, dst);
+        gd_copy_mat4f((const Mat4f *)&rot, dst);
     }
 }

--- a/src/goddard/joints.c
+++ b/src/goddard/joints.c
@@ -364,7 +364,7 @@ void func_8018F520(struct ObjBone *b) {
     gd_normalize_vec3f(&sp84);
     sp64 = gd_vec3f_magnitude(&sp78);
     gd_create_rot_mat_angular(&mtx, &sp84, sp64);
-    gd_mult_mat4f(&b->mat70, &mtx, &b->mat70);
+    gd_mult_mat4f((const Mat4f *)&b->mat70, (const Mat4f *)&mtx, &b->mat70);
     D_801BA968.x = b->mat70[2][0];
     D_801BA968.y = b->mat70[2][1];
     D_801BA968.z = b->mat70[2][2];
@@ -392,8 +392,8 @@ void func_8018F89C(struct ObjBone *b) {
     b->unk14.y = (spAC->unk14.y + spA8->unk14.y) / 2.0; //? 2.0f;
     b->unk14.z = (spAC->unk14.z + spA8->unk14.z) / 2.0; //? 2.0f;
 
-    gd_mult_mat4f(&b->matB0, &gGdSkinNet->mat128, &mtx);
-    gd_copy_mat4f(&mtx, &b->mat70);
+    gd_mult_mat4f((const Mat4f *)&b->matB0, (const Mat4f *)&gGdSkinNet->mat128, &mtx);
+    gd_copy_mat4f((const Mat4f *)&mtx, &b->mat70);
 
     D_801BA968.x = -b->mat70[2][0];
     D_801BA968.y = -b->mat70[2][1];
@@ -833,7 +833,7 @@ void func_80190B54(struct ObjJoint *a0, struct ObjJoint *a1, struct GdVec3f *a2)
         sp78 = gd_vec3f_magnitude(&sp80);
         gd_normalize_vec3f(&sp80);
         gd_create_rot_mat_angular(&sp38, &sp80, sp78);
-        gd_mult_mat4f(&a0->matE8, &sp38, &a0->matE8);
+        gd_mult_mat4f((const Mat4f *)&a0->matE8, (const Mat4f *)&sp38, &a0->matE8);
 
     } else {
         D_801BAAE0.x = a2->x;
@@ -919,7 +919,7 @@ void func_801911A8(struct ObjJoint *j) {
     j->unkCC.y = j->unkC0.y;
     j->unkCC.z = j->unkC0.z;
 
-    gd_rotate_and_translate_vec3f(&j->unkCC, &gGdSkinNet->mat128);
+    gd_rotate_and_translate_vec3f(&j->unkCC, (const Mat4f *)&gGdSkinNet->mat128);
 }
 
 /* 23F9F0 -> 23FB90 */
@@ -928,7 +928,7 @@ void func_80191220(struct ObjJoint *j) {
     j->unk48.y = j->unk54.y;
     j->unk48.z = j->unk54.z;
 
-    gd_mat4f_mult_vec3f(&j->unk48, &gGdSkinNet->mat128);
+    gd_mat4f_mult_vec3f(&j->unk48, (const Mat4f *)&gGdSkinNet->mat128);
     j->unk3C.x = j->unk48.x;
     j->unk3C.y = j->unk48.y;
     j->unk3C.z = j->unk48.z;
@@ -963,7 +963,7 @@ void func_801913F0(struct ObjJoint *j) {
     j->unk30.y = j->unk14.y;
     j->unk30.z = j->unk14.z;
 
-    gd_copy_mat4f(&gGdSkinNet->mat128, &j->matE8);
+    gd_copy_mat4f((const Mat4f *)&gGdSkinNet->mat128, &j->matE8);
 }
 
 /* 23FCC8 -> 23FCDC */
@@ -981,7 +981,7 @@ void func_8019150C(Mat4f *a0, struct GdVec3f *a1) {
     a1->x += sp1C.x;
     a1->y += sp1C.y;
     a1->z += sp1C.z;
-    gd_mat4f_mult_vec3f(a1, a0);
+    gd_mat4f_mult_vec3f(a1, (const Mat4f *)a0);
 }
 
 /* 23FDD4 -> 23FFF4 */
@@ -1007,7 +1007,7 @@ void func_80191604(struct ObjJoint *j) {
     gd_scale_mat4f_by_vec3f(&j->mat168, (struct GdVec3f *) &j->unk9C);
     gd_rot_mat_about_vec(&j->mat168, (struct GdVec3f *) &j->unk6C);
     gd_add_vec3f_to_mat4f_offset(&j->mat168, &j->unk200);
-    gd_copy_mat4f(&j->mat168, &j->matE8);
+    gd_copy_mat4f((const Mat4f *)&j->mat168, &j->matE8);
 
     gd_set_identity_mat4(&j->mat128);
     gd_add_vec3f_to_mat4f_offset(&j->mat128, &j->unk54);

--- a/src/goddard/objects.c
+++ b/src/goddard/objects.c
@@ -1106,7 +1106,7 @@ void func_8017E584(struct ObjNet *a0, struct GdVec3f *a1, struct GdVec3f *a2) {
     sp1C.y = a0->unkB0.y;
     sp1C.z = a0->unkB0.z;
 
-    gd_rotate_and_translate_vec3f(&sp1C, &a0->mat128);
+    gd_rotate_and_translate_vec3f(&sp1C, (const Mat4f *)&a0->mat128);
 
     sp7C.x -= sp1C.x;
     sp7C.y -= sp1C.y;
@@ -1155,7 +1155,7 @@ void func_8017E838(struct ObjNet *a0, struct GdVec3f *a1, struct GdVec3f *a2) {
     sp18.y = a0->unkB0.y;
     sp18.z = a0->unkB0.z;
 
-    gd_rotate_and_translate_vec3f(&sp18, &a0->mat128);
+    gd_rotate_and_translate_vec3f(&sp18, (const Mat4f *)&a0->mat128);
 
     sp64.x -= sp18.x;
     sp64.y -= sp18.y;
@@ -1186,7 +1186,7 @@ void func_8017E9EC(struct ObjNet *a0) {
     gd_normalize_vec3f(&sp5C);
     sp18 = gd_vec3f_magnitude(&a0->unkA4);
     gd_create_rot_mat_angular(&sp1C, &sp5C, -sp18);
-    gd_mult_mat4f(&D_801B9DC8, &sp1C, &D_801B9DC8);
+    gd_mult_mat4f((const Mat4f *)&D_801B9DC8, (const Mat4f *)&sp1C, &D_801B9DC8);
 }
 
 /* @ 22D264 for 0x90 */
@@ -1344,8 +1344,8 @@ s32 func_8017F054(struct GdObj *a0, struct GdObj *a1) {
         d_get_scale(&sp1C);
         sp48 = d_get_matrix_ptr();
 
-        gd_mult_mat4f(sp4C, sp50, sp48);
-        gd_mult_mat4f(sp4C, sp44, sp40);
+        gd_mult_mat4f((const Mat4f *)sp4C, (const Mat4f *)sp50, sp48);
+        gd_mult_mat4f((const Mat4f *)sp4C, (const Mat4f *)sp44, sp40);
         gd_scale_mat4f_by_vec3f(sp40, &sp1C);
     } else {
         set_cur_dynobj(a0);
@@ -1355,7 +1355,7 @@ s32 func_8017F054(struct GdObj *a0, struct GdObj *a1) {
 
         d_get_scale(&sp1C);
         gd_set_identity_mat4(sp48);
-        gd_copy_mat4f(sp4C, sp44);
+        gd_copy_mat4f((const Mat4f *)sp4C, sp44);
         gd_scale_mat4f_by_vec3f(sp44, &sp1C);
     }
 
@@ -1398,7 +1398,7 @@ s32 func_8017F210(struct GdObj *a0, struct GdObj *a1) {
         sp50 = (Mat4f *) d_get_rot_mtx_ptr();
 
         d_get_scale(&sp2C);
-        gd_mult_mat4f(sp5C, sp54, sp50);
+        gd_mult_mat4f((const Mat4f *)sp5C, (const Mat4f *)sp54, sp50);
         gd_scale_mat4f_by_vec3f(sp50, &sp2C);
     } else {
         set_cur_dynobj(a0);
@@ -1407,7 +1407,7 @@ s32 func_8017F210(struct GdObj *a0, struct GdObj *a1) {
         sp54 = (Mat4f *) d_get_rot_mtx_ptr();
 
         d_get_scale(&sp2C);
-        gd_copy_mat4f(sp5C, sp54);
+        gd_copy_mat4f((const Mat4f *)sp5C, sp54);
         gd_scale_mat4f_by_vec3f(sp54, &sp2C);
     }
 
@@ -1426,7 +1426,7 @@ s32 func_8017F210(struct GdObj *a0, struct GdObj *a1) {
 
 /* @ 22DB9C for 0x38; a0 might be ObjUnk200000* */
 void func_8017F3CC(struct Unk8017F3CC *a0) {
-    gd_rotate_and_translate_vec3f(&a0->unk20, D_801B9E48);
+    gd_rotate_and_translate_vec3f(&a0->unk20, (const Mat4f *)D_801B9E48);
 }
 
 /* @ 22DBD4 for 0x20 */
@@ -1724,7 +1724,7 @@ void drag_picked_object(struct GdObj *inputObj) {
     spD0.z = 0.0f;
 
     gd_inverse_mat4f(&gViewUpdateCamera->unkE8, &sp40);
-    gd_mat4f_mult_vec3f(&spD0, &sp40);
+    gd_mat4f_mult_vec3f(&spD0, (const Mat4f *)&sp40);
 
     obj = inputObj;
     if ((inputObj->drawFlags & OBJ_PICKED) && gGdCtrl.btnApressed) {
@@ -1748,7 +1748,7 @@ void drag_picked_object(struct GdObj *inputObj) {
                 spC4.y = spD0.y;
                 spC4.z = spD0.z;
 
-                gd_mat4f_mult_vec3f(&spC4, &sp80);
+                gd_mat4f_mult_vec3f(&spC4, (const Mat4f *)&sp80);
                 ((struct ObjNet *) obj)->matE8[3][0] += spD0.x;
                 ((struct ObjNet *) obj)->matE8[3][1] += spD0.y;
                 ((struct ObjNet *) obj)->matE8[3][2] += spD0.z;
@@ -1880,8 +1880,8 @@ void move_camera(struct ObjCamera *cam) {
     spD4.y += spB0.y;
     spD4.z += spB0.z;
 
-    gd_mult_mat4f(sp2C, &cam->unkA8, &cam->unkA8);
-    gd_mat4f_mult_vec3f(&spD4, &cam->unkA8);
+    gd_mult_mat4f((const Mat4f *)sp2C, (const Mat4f *)&cam->unkA8, &cam->unkA8);
+    gd_mat4f_mult_vec3f(&spD4, (const Mat4f *)&cam->unkA8);
 
     cam->unk14.x = spD4.x;
     cam->unk14.y = spD4.y;
@@ -1946,14 +1946,14 @@ void func_8018100C(struct ObjLight *light) {
     gd_absrot_mat4(&mtx, GD_Y_AXIS, light->unk68.y);
     gd_absrot_mat4(&mtx, GD_X_AXIS, light->unk68.x);
     gd_absrot_mat4(&mtx, GD_Z_AXIS, light->unk68.z);
-    gd_mat4f_mult_vec3f(&light->unk8C, &mtx);
+    gd_mat4f_mult_vec3f(&light->unk8C, (const Mat4f *)&mtx);
 
     light->position.x = light->unk8C.x;
     light->position.y = light->unk8C.y;
     light->position.z = light->unk8C.z;
     return;
     // even more unreachable
-    gd_mat4f_mult_vec3f(&light->unk80, &mtx);
+    gd_mat4f_mult_vec3f(&light->unk80, (const Mat4f *)&mtx);
     imout(); // this call would cause an issue if it was reachable
 }
 

--- a/src/goddard/renderer.c
+++ b/src/goddard/renderer.c
@@ -3678,7 +3678,7 @@ void func_801A71CC(struct ObjNet *net) {
         net->unk21C = make_group(0);
     }
 
-    gd_print_plane("making zones for net=", &net->unkBC);
+    gd_print_plane("making zones for net=", (const struct GdPlaneF *)&net->unkBC);
 
     sp64.x = (ABS(net->unkBC.p0.x) + ABS(net->unkBC.p1.x)) / 16.0f;
     sp64.z = (ABS(net->unkBC.p0.z) + ABS(net->unkBC.p1.z)) / 16.0f;
@@ -3739,7 +3739,7 @@ void func_801A71CC(struct ObjNet *net) {
         planeL3 = (struct ObjPlane *) link3->obj;
 
         if (!planeL3->unk18) {
-            gd_print_plane("plane=", &planeL3->plane28);
+            gd_print_plane("plane=", (const struct GdPlaneF *)&planeL3->plane28);
             fatal_printf("plane not in any zones\n");
         }
     }

--- a/src/goddard/shape_helper.c
+++ b/src/goddard/shape_helper.c
@@ -541,7 +541,7 @@ void Unknown801985E8(struct ObjShape *shape) {
     D_801BAD30.y = (f32)((sp18.p0.y + sp18.p1.y) / 2.0); //? 2.0f
     D_801BAD30.z = (f32)((sp18.p0.z + sp18.p1.z) / 2.0); //? 2.0f
 
-    gd_print_vec("c=", &D_801BAD30);
+    gd_print_vec("c=", (const struct GdVec3f *)&D_801BAD30);
 
     apply_to_obj_types_in_group(OBJ_TYPE_VERTICES, (applyproc_t) Unknown80198524, shape->vtxGroup);
 }

--- a/src/goddard/skin.c
+++ b/src/goddard/skin.c
@@ -58,8 +58,8 @@ void reset_net(struct ObjNet *net) {
     net->unkA4.x = net->unkA4.y = net->unkA4.z = 0.0f;
 
     func_80191F10(net);
-    gd_print_vec("net scale: ", &net->unk1AC);
-    gd_print_plane("net box: ", &net->unkBC);
+    gd_print_vec("net scale: ", (const struct GdVec3f *)&net->unk1AC);
+    gd_print_plane("net box: ", (const struct GdPlaneF *)&net->unkBC);
 
     gGdSkinNet = net;
     D_801BAAF4 = 0;
@@ -67,7 +67,7 @@ void reset_net(struct ObjNet *net) {
     gd_set_identity_mat4(&net->matE8);
     gd_rot_mat_about_vec(&net->matE8, &net->unk68); // set rot mtx to initial rotation?
     gd_add_vec3f_to_mat4f_offset(&net->matE8, &net->unk14); // set to initial position?
-    gd_copy_mat4f(&net->matE8, &net->mat128);
+    gd_copy_mat4f((const Mat4f *)&net->matE8, &net->mat128);
 
     if ((grp = net->unk1C8) != NULL) {
         apply_to_obj_types_in_group(OBJ_TYPE_JOINTS, (applyproc_t) func_80191604, grp);
@@ -213,7 +213,7 @@ void func_80192AD0(struct ObjNet *net) {
     net->unk14.x = net->unk1F4.x;
     net->unk14.y = net->unk1F4.y;
     net->unk14.z = net->unk1F4.z;
-    gd_rotate_and_translate_vec3f(&net->unk14, &sp18->mat128);
+    gd_rotate_and_translate_vec3f(&net->unk14, (const Mat4f *)&sp18->mat128);
 
     net->unk14.x += net->unk1F0->unk14.x;
     net->unk14.y += net->unk1F0->unk14.y;
@@ -221,7 +221,7 @@ void func_80192AD0(struct ObjNet *net) {
     net->unk200.x = 0.0f;
     net->unk200.y = 10.0f;
     net->unk200.z = -4.0f;
-    gd_rotate_and_translate_vec3f(&net->unk200, &sp18->mat128);
+    gd_rotate_and_translate_vec3f(&net->unk200, (const Mat4f *)&sp18->mat128);
 
     apply_to_obj_types_in_group(OBJ_TYPE_JOINTS, (applyproc_t) func_80191824, sp60);
     func_80191E88(sp60);
@@ -259,7 +259,7 @@ void func_80192CCC(struct ObjNet *net) {
         sp24.y = net->mat128[0][1];
         sp24.z = net->mat128[0][2];
         gd_create_rot_mat_angular(&sp38, &sp24, 4.0f);
-        gd_mult_mat4f(&sp38, &D_801B9DC8, &D_801B9DC8);
+        gd_mult_mat4f((const Mat4f *)&sp38, (const Mat4f *)&D_801B9DC8, &D_801B9DC8);
         net->unkA4.x = net->unkA4.y = net->unkA4.z = 0.0f;
     }
 
@@ -268,7 +268,7 @@ void func_80192CCC(struct ObjNet *net) {
         sp24.y = net->mat128[0][1];
         sp24.z = net->mat128[0][2];
         gd_create_rot_mat_angular(&sp38, &sp24, -4.0f);
-        gd_mult_mat4f(&sp38, &D_801B9DC8, &D_801B9DC8);
+        gd_mult_mat4f((const Mat4f *)&sp38, (const Mat4f *)&D_801B9DC8, &D_801B9DC8);
         net->unkA4.x = net->unkA4.y = net->unkA4.z = 0.0f;
     }
 
@@ -290,7 +290,7 @@ void func_80192CCC(struct ObjNet *net) {
     }
 
     func_801926A4(net);
-    gd_mult_mat4f(&net->mat128, &D_801B9DC8, &net->mat128);
+    gd_mult_mat4f((const Mat4f *)&net->mat128, (const Mat4f *)&D_801B9DC8, &net->mat128);
     if (group != NULL) {
         apply_to_obj_types_in_group(OBJ_TYPE_JOINTS, (applyproc_t) func_801913C0, group);
         apply_to_obj_types_in_group(OBJ_TYPE_BONES, (applyproc_t) func_8018FA68, group);
@@ -494,27 +494,27 @@ void func_80193848(struct ObjGroup *group) {
 /* 24208C -> 2422E0; not called; orig name: func_801938BC */
 void gd_print_net(struct ObjNet *net) {
     gd_printf("Flags:%x\n", net->unk34);
-    gd_print_vec("World:", &net->unk14);
-    gd_print_vec("Force:", &net->unk44);
-    gd_print_vec("Vel:", &net->unk50);
-    gd_print_vec("Rot:", &net->unk5C);
-    gd_print_vec("CollDisp:", &net->unk74);
-    gd_print_vec("CollTorque:", &net->unk80);
-    gd_print_vec("CollTorqueL:", &net->unk8C);
-    gd_print_vec("CollTorqueD:", &net->unk98);
-    gd_print_vec("Torque:", &net->unkA4);
-    gd_print_vec("CofG:", &net->unkB0);
-    gd_print_plane("BoundBox:", &net->unkBC);
-    gd_print_vec("CollDispOff:", &net->unkD4);
+    gd_print_vec("World:", (const struct GdVec3f *)&net->unk14);
+    gd_print_vec("Force:", (const struct GdVec3f *)&net->unk44);
+    gd_print_vec("Vel:", (const struct GdVec3f *)&net->unk50);
+    gd_print_vec("Rot:", (const struct GdVec3f *)&net->unk5C);
+    gd_print_vec("CollDisp:", (const struct GdVec3f *)&net->unk74);
+    gd_print_vec("CollTorque:", (const struct GdVec3f *)&net->unk80);
+    gd_print_vec("CollTorqueL:", (const struct GdVec3f *)&net->unk8C);
+    gd_print_vec("CollTorqueD:", (const struct GdVec3f *)&net->unk98);
+    gd_print_vec("Torque:", (const struct GdVec3f *)&net->unkA4);
+    gd_print_vec("CofG:", (const struct GdVec3f *)&net->unkB0);
+    gd_print_plane("BoundBox:", (const struct GdPlaneF *)&net->unkBC);
+    gd_print_vec("CollDispOff:", (const struct GdVec3f *)&net->unkD4);
     gd_printf("CollMaxD: %f\n", net->unkE0);
     gd_printf("MaxRadius: %f\n", net->unkE4);
-    gd_print_mtx("Matrix:", &net->mat128);
+    gd_print_mtx("Matrix:", (const Mat4f *)&net->mat128);
     if (net->unk1A8 != NULL) {
         gd_printf("ShapePtr: %x (%s)\n", (u32) (uintptr_t) net->unk1A8, net->unk1A8->name);
     } else {
         gd_printf("ShapePtr: NULL\n");
     }
-    gd_print_vec("Scale:", &net->unk1AC);
+    gd_print_vec("Scale:", (const struct GdVec3f *)&net->unk1AC);
     gd_printf("Mass: %f\n", net->unk1B8);
     gd_printf("NumModes: %d\n", net->unk1BC);
     gd_printf("NodeGroup: %x\n", (u32) (uintptr_t) net->unk1C8);

--- a/src/goddard/skin_movement.c
+++ b/src/goddard/skin_movement.c
@@ -94,7 +94,7 @@ void func_80181894(struct ObjJoint *joint) {
                 stackVec.x = curWeight->vec20.x;
                 stackVec.y = curWeight->vec20.y;
                 stackVec.z = curWeight->vec20.z;
-                gd_rotate_and_translate_vec3f(&stackVec, &joint->matE8);
+                gd_rotate_and_translate_vec3f(&stackVec, (const Mat4f *)&joint->matE8);
 
                 connectedVtx = curWeight->unk3C;
                 scaleFactor = curWeight->unk38;
@@ -118,7 +118,7 @@ void func_801819D0(struct ObjVertex *vtx) {
         localVec.y = vtx->pos.y;
         localVec.z = vtx->pos.z;
 
-        gd_rotate_and_translate_vec3f(&localVec, &D_801B9EA8);
+        gd_rotate_and_translate_vec3f(&localVec, (const Mat4f *)&D_801B9EA8);
         sSkinNetCurWeight->vec20.x = localVec.x;
         sSkinNetCurWeight->vec20.y = localVec.y;
         sSkinNetCurWeight->vec20.z = localVec.z;

--- a/src/pc/gfx/gfx_gldc.c
+++ b/src/pc/gfx/gfx_gldc.c
@@ -618,7 +618,7 @@ static void gfx_opengl_init(void) {
     config.autosort_enabled = GL_TRUE;
     config.fsaa_enabled = GL_FALSE;
     /*@Note: These should be adjusted at some point */
-    config.initial_op_capacity = 3072;
+    config.initial_op_capacity = 3584;
     config.initial_pt_capacity = 1024;
     config.initial_tr_capacity = 2048;
     config.initial_immediate_capacity = 0;

--- a/src/pc/gfx/gfx_retro_dc.c
+++ b/src/pc/gfx/gfx_retro_dc.c
@@ -565,7 +565,7 @@ static void calculate_normal_dir(const Light_t *light, float coeffs[3]) {
         light->dir[1] / 127.0f,
         light->dir[2] / 127.0f
     };
-    gfx_transposed_matrix_mul(coeffs, light_dir, rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1]);
+    gfx_transposed_matrix_mul(coeffs, light_dir, (const float (*)[4])rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1]);
     gfx_normalize_vector(coeffs);
 }
 
@@ -606,7 +606,7 @@ static void gfx_sp_matrix(uint8_t parameters, const int32_t *addr) {
         if (parameters & G_MTX_LOAD) {
             memcpy(rsp.P_matrix, matrix, sizeof(matrix));
         } else {
-            gfx_matrix_mul(rsp.P_matrix, matrix, rsp.P_matrix);
+            gfx_matrix_mul(rsp.P_matrix, (const float (*)[4])matrix, (const float (*)[4])rsp.P_matrix);
         }
         glMatrixMode(GL_PROJECTION);
         glLoadMatrixf((const float*)rsp.P_matrix);
@@ -618,13 +618,13 @@ static void gfx_sp_matrix(uint8_t parameters, const int32_t *addr) {
         if (parameters & G_MTX_LOAD) {
             memcpy(rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1], matrix, sizeof(matrix));
         } else {
-            gfx_matrix_mul(rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1], matrix, rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1]);
+            gfx_matrix_mul(rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1], (const float (*)[4])matrix, (const float (*)[4])rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1]);
         }
         glMatrixMode(GL_MODELVIEW);
         glLoadMatrixf((const float*)rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1]);
         rsp.lights_changed = 1;
     }
-    gfx_matrix_mul(rsp.MP_matrix, rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1], rsp.P_matrix);
+    gfx_matrix_mul(rsp.MP_matrix, (const float (*)[4])rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1], (const float (*)[4])rsp.P_matrix);
 }
 
 static void gfx_sp_pop_matrix(uint32_t count) {
@@ -634,7 +634,7 @@ static void gfx_sp_pop_matrix(uint32_t count) {
         }
     }
     if (rsp.modelview_matrix_stack_size > 0) {
-        gfx_matrix_mul(rsp.MP_matrix, rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1], rsp.P_matrix);
+        gfx_matrix_mul(rsp.MP_matrix, (const float (*)[4])rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1], (const float (*)[4])rsp.P_matrix);
         glMatrixMode(GL_MODELVIEW);
         glLoadMatrixf((const float*)rsp.modelview_matrix_stack[rsp.modelview_matrix_stack_size - 1]);
     }


### PR DESCRIPTION
- fixes gcc 4.7.3 dc toolchain warnings
- code doesnt change
- remove worthless return from math_util.c